### PR TITLE
Debian as docker base image and fail2ban added to improve security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,20 @@
-FROM ubuntu:trusty
-MAINTAINER Feng Honglin <hfeng@tutum.co>
+FROM debian:bookworm-slim
+LABEL maintainer="Feng Honglin <hfeng@tutum.co>"
 
 RUN apt-get update && \
-    apt-get -y --no-install-recommends install openssh-server autossh pwgen sshpass && \
+    apt-get -y --no-install-recommends install openssh-server autossh pwgen sshpass fail2ban && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists && \
     mkdir -p /var/run/sshd && \
     mkdir -p /root/.ssh && \
-    sed -i "s/UsePrivilegeSeparation.*/UsePrivilegeSeparation no/g" /etc/ssh/sshd_config && \
-    sed -i "s/UsePAM.*/UsePAM no/g" /etc/ssh/sshd_config && \
-    sed -i "s/PermitRootLogin.*/PermitRootLogin yes/g" /etc/ssh/sshd_config && \
-    echo "GatewayPorts yes" >> /etc/ssh/sshd_config && \
+    sed -i '/.*UsePrivilegeSeparation.*/s/^/# /' /etc/ssh/sshd_config && \
+    sed -i '/.*UsePAM.*/s/^/# /' /etc/ssh/sshd_config && \
+    sed -i '/.*PermitRootLogin.*/s/^/# /' /etc/ssh/sshd_config && \
+    sed -i '/.*GatewayPorts.*/s/^/# /' /etc/ssh/sshd_config && \
+    echo '# Docker configuration' >> /etc/ssh/sshd_config && \
+    echo 'UsePrivilegeSeparation no' >> /etc/ssh/sshd_config && \
+    echo 'UsePAM no' >> /etc/ssh/sshd_config && \
+    echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config && \
+    echo 'GatewayPorts yes' >> /etc/ssh/sshd_config && \
     rm -rf /var/lib/apt/lists/*
 
 ADD run.sh /run.sh

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ On public host, run:
     -e ROOT_PASS=<your_password> \
     -p <your_sshd_port>:22 \
     -p <forwarding_port>:1080 \
+    --name=rssh-tunnel-host \
     tifayuki/reverse-ssh-tunnel
 ```
 Parameters:
@@ -33,6 +34,7 @@ On NATed Host, run:
     -e ROOT_PASS=<your_password> \
     -e PROXY_PORT=<NATed_service_port> \
     --net=host \
+    --name=rssh-tunnel-natted \
     tifayuki/reverse-ssh-tunnel
 ```
 Parameters:

--- a/run.sh
+++ b/run.sh
@@ -49,7 +49,7 @@ if [[ -n "${PUBLIC_HOST_ADDR}" && -n "${PUBLIC_HOST_PORT}" ]]; then
         echo "ROOT_PASS needs to be specified!"
     fi
 
-    echo "=> Connecting to Remote SSH servier ${PUBLIC_HOST_ADDR}:${PUBLIC_HOST_PORT}"
+    echo "=> Connecting to Remote SSH server ${PUBLIC_HOST_ADDR}:${PUBLIC_HOST_PORT}"
 
     KNOWN_HOSTS="/root/.ssh/known_hosts"
     if [ !-f ${KNOWN_HOST} ]; then


### PR DESCRIPTION
Base image switched to Debian to take advantage of more architecture coverage.

In my case, I wanted to make it work natted instance in a raspberry pi 1 model b with no luck because ubuntu:trusty doesn't have images for armv6l.

Also debian:*-slim images are smaller so build will take less time.